### PR TITLE
Fix chatbot truncation and clean up portfolio UI

### DIFF
--- a/api/portfolio-chat.js
+++ b/api/portfolio-chat.js
@@ -657,7 +657,7 @@ function buildSystemInstruction(sources) {
     "If the user uploaded a file, you may describe that file too, but keep portfolio claims grounded only in those source excerpts.",
     "Reply in the same language as the user's latest message.",
     "Default to a tight answer: at most 1 short paragraph or 3 bullets unless the user explicitly asks for detail.",
-    "Unless the user asks for depth, stay under roughly 90 words.",
+    "Unless the user asks for depth, stay under roughly 200 words. Always finish your sentence — never cut off mid-sentence.",
     "If the answer is not supported by the excerpts, say you could not confirm it from the portfolio sources.",
     "Keep the answer concise, factual, and useful.",
     "Do not invent achievements, dates, roles, clients, awards, or employers.",
@@ -681,7 +681,7 @@ async function generateAnswer(apiKey, question, history, sources, attachment) {
     generationConfig: {
       temperature: 0.15,
       topP: 0.8,
-      maxOutputTokens: 260,
+      maxOutputTokens: 1500,
       responseMimeType: "text/plain",
     },
   });

--- a/index.html
+++ b/index.html
@@ -112,7 +112,6 @@
               target="_blank" rel="noopener noreferrer" class="highlight">various languages</a>, reaching thousands of
             readers in Brazil and abroad.</p>
           <div class="hero-actions">
-            <a href="#portfolio-chat" class="btn">Ask the portfolio assistant</a>
             <a href="resume.html" class="btn btn-secondary">View resume</a>
           </div>
         </div>

--- a/portfolio-chat-api/api/portfolio-chat.js
+++ b/portfolio-chat-api/api/portfolio-chat.js
@@ -657,7 +657,7 @@ function buildSystemInstruction(sources) {
     "If the user uploaded a file, you may describe that file too, but keep portfolio claims grounded only in those source excerpts.",
     "Reply in the same language as the user's latest message.",
     "Default to a tight answer: at most 1 short paragraph or 3 bullets unless the user explicitly asks for detail.",
-    "Unless the user asks for depth, stay under roughly 90 words.",
+    "Unless the user asks for depth, stay under roughly 200 words. Always finish your sentence — never cut off mid-sentence.",
     "If the answer is not supported by the excerpts, say you could not confirm it from the portfolio sources.",
     "Keep the answer concise, factual, and useful.",
     "Do not invent achievements, dates, roles, clients, awards, or employers.",
@@ -681,7 +681,7 @@ async function generateAnswer(apiKey, question, history, sources, attachment) {
     generationConfig: {
       temperature: 0.15,
       topP: 0.8,
-      maxOutputTokens: 260,
+      maxOutputTokens: 1500,
       responseMimeType: "text/plain",
     },
   });


### PR DESCRIPTION
## Summary
- Aumenta `maxOutputTokens` de 800 para 1500 e limite de palavras de 90 para 200 no chatbot — resolve respostas cortadas no meio da frase
- Adiciona instrução explícita para nunca cortar resposta mid-sentence
- Remove botão "Ask the portfolio assistant" da seção hero (chatbot continua acessível rolando a página)

## Itens já presentes (sem alteração necessária)
- Reel do Instagram (`DVwcNVPAQ0_`) já era o primeiro item no carrossel
- Link `pesquisa_ampla` já estava no bloco Civil Tech

🤖 Generated with [Claude Code](https://claude.com/claude-code)