### PR TITLE
Add missing short-form reel and pesquisa_ampla link

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
             <p>Over the last three years, I have used generative AI in journalism for data analysis and
               investigations. In 2025, I built a <a href="https://datafixers.org/l-ai-notebook.html" target="_blank"
                 rel="noopener noreferrer" class="highlight">tool</a> that helps reporters search millions of Brazilian
-              public records. In 2026, I launched <a href="https://datafixers.org/index_en.html#dashboards"
+              public records, e <a href="https://luizftoledo.github.io/pesquisa_ampla/" target="_blank" rel="noopener noreferrer" class="highlight">uma ferramenta que permite pesquisar em várias bases de dados públicas ao mesmo tempo</a>. In 2026, I launched <a href="https://datafixers.org/index_en.html#dashboards"
                 target="_blank" rel="noopener noreferrer" class="highlight">public-interest data analysis
                 dashboards</a> on Datafixers.
             </p>
@@ -506,6 +506,8 @@
         <div class="reels-carousel-container">
           <button class="reels-btn reels-btn-left" aria-label="Scroll left"><i class="fas fa-chevron-left"></i></button>
           <div class="reels-carousel">
+            <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/reel/DVwcNVPAQ0_/?igsh=MXR4a216aW9jenkzbA%3D%3D"
+              data-instgrm-version="14"></blockquote>
             <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/DVO4gD_j5T4/"
               data-instgrm-version="14"></blockquote>
             <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/DUi12gSEaFV/"


### PR DESCRIPTION
## Summary
- Adiciona reel do Instagram (DVwcNVPAQ0_) como primeiro item no carrossel de short-form
- Adiciona link pesquisa_ampla no bloco Civil Tech com o texto solicitado

🤖 Generated with [Claude Code](https://claude.com/claude-code)