### PR TITLE
feat: add government plans dashboard for 2024 municipal elections

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,8 @@
                 rel="noopener noreferrer" class="highlight">tool</a> that helps reporters search millions of Brazilian
               public records, as well as a <a href="https://luizftoledo.github.io/pesquisa_ampla/" target="_blank" rel="noopener noreferrer" class="highlight">platform to search across multiple public databases simultaneously</a>. In 2026, I launched an <a href="simulador-reacoes/index.html" class="highlight">AI-powered news reaction simulator</a> and public-interest data analysis <a href="https://datafixers.org/index_en.html#dashboards"
                 target="_blank" rel="noopener noreferrer" class="highlight">dashboards</a> on Datafixers.
+              I also built a <a href="planos-governo-dashboard/" class="highlight">searchable database of government plans</a>
+              submitted by all mayoral candidates in the 2024 Brazilian municipal elections — with keyword search, topic analysis, party comparisons and plagiarism detection across 50,000+ documents.
             </p>
           </div>
         </div>

--- a/planos-governo-dashboard/app.js
+++ b/planos-governo-dashboard/app.js
@@ -1,0 +1,952 @@
+/* =========================================================================
+   Planos de Governo 2024 – Dashboard
+   =========================================================================
+   Todos os dados vêm de JSONs em ./data/ gerados pelo script Python.
+   Estratégia de carregamento:
+     • metadata.json  → sempre carregado (lista leve de todos os candidatos)
+     • report.json    → estatísticas gerais (carregado na inicialização)
+     • themes.json    → índice de temas (carregado na inicialização)
+     • themes/{slug}  → lazy: só quando o usuário clica no tema
+     • states/{UF}    → lazy: só quando o usuário filtra por UF
+     • candidates/{id}→ lazy: só para comparação ou detalhe
+     • parties.json   → lazy: quando abre a aba partidos
+     • plagiarism.json→ lazy: quando abre a aba plágio
+   ========================================================================= */
+
+"use strict";
+
+(function () {
+
+/* ── constantes ──────────────────────────────────────────────────────────── */
+
+const DATA  = "./data";
+const STATES = [
+  "AC","AL","AM","AP","BA","CE","DF","ES","GO","MA",
+  "MG","MS","MT","PA","PB","PE","PI","PR","RJ","RN",
+  "RO","RR","RS","SC","SE","SP","TO",
+];
+const PAGE_SIZE = 20;
+
+/* ── estado global ───────────────────────────────────────────────────────── */
+
+const S = {
+  metadata:   null,   // array de todos os candidatos (sem texto)
+  report:     null,
+  themes:     null,   // índice [{name,slug,count}]
+  parties:    null,
+  plagiarism: null,
+  stateCache: {},     // {UF: [candidatos com snippet]}
+  themeCache: {},     // {slug: data}
+  candCache:  {},     // {id: {text,...}}
+
+  // busca keyword
+  kwResults:  [],
+  kwPage:     0,
+
+  // tema selecionado
+  activeTheme:    null,
+  activeThemeAll: [],
+  activeThemeFlt: [],
+  trPage:         0,
+
+  // plágio
+  plagFiltered: [],
+  plagPage:     0,
+
+  // VS
+  vsA: null,
+  vsB: null,
+
+  partyData: null,
+};
+
+/* ── utilidades ──────────────────────────────────────────────────────────── */
+
+const nFmt  = new Intl.NumberFormat("pt-BR");
+const pFmt  = new Intl.NumberFormat("pt-BR", { maximumFractionDigits: 1 });
+
+function norm(s = "") {
+  return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+}
+
+function esc(s = "") {
+  return String(s)
+    .replace(/&/g,"&amp;").replace(/</g,"&lt;")
+    .replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+}
+
+function highlight(text = "", kw = "") {
+  if (!kw) return esc(text);
+  const re = new RegExp("(" + kw.replace(/[.*+?^${}()|[\]\\]/g,"\\$&") + ")", "gi");
+  return esc(text).replace(re, "<mark>$1</mark>");
+}
+
+/** Marca no texto normalizado e extrai o trecho do texto original */
+function extractSnippet(text = "", kw = "", len = 300) {
+  if (!text) return "";
+  const tn  = norm(text);
+  const kwn = norm(kw);
+  const idx = tn.indexOf(kwn);
+  if (idx === -1) return text.slice(0, len);
+  const s = Math.max(0, idx - 80);
+  const e = Math.min(text.length, idx + kwn.length + 180);
+  return (s > 0 ? "…" : "") + text.slice(s, e).trim() + (e < text.length ? "…" : "");
+}
+
+async function fetchJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`${r.status} ${url}`);
+  return r.json();
+}
+
+function spinner() {
+  return `<div class="loading"><div class="spinner"></div> carregando…</div>`;
+}
+
+/* ── tabs ────────────────────────────────────────────────────────────────── */
+
+document.querySelectorAll(".tab-btn").forEach(btn => {
+  btn.addEventListener("click", () => {
+    document.querySelectorAll(".tab-btn").forEach(b => b.classList.remove("active"));
+    document.querySelectorAll(".tab-pane").forEach(p => p.classList.remove("active"));
+    btn.classList.add("active");
+    const id = "tab-" + btn.dataset.tab;
+    document.getElementById(id).classList.add("active");
+
+    // lazy loads por aba
+    if (btn.dataset.tab === "partidos" && !S.parties) loadParties();
+    if (btn.dataset.tab === "plagio"   && !S.plagiarism) loadPlagiarism();
+  });
+});
+
+/* ── inicialização ───────────────────────────────────────────────────────── */
+
+async function init() {
+  try {
+    const [meta, report, themes] = await Promise.all([
+      fetchJSON(`${DATA}/metadata.json`),
+      fetchJSON(`${DATA}/report.json`),
+      fetchJSON(`${DATA}/themes.json`),
+    ]);
+    S.metadata = meta;
+    S.report   = report;
+    S.themes   = themes;
+
+    renderKPIs();
+    renderHeroReport();
+    populateFilters();
+    renderStateCoverage();
+    renderThemeGrid();
+    renderThemeBarChart();
+    renderPartyBarChart();
+    setupBuscador();
+    setupVS();
+    setupPartidosTab();
+
+  } catch (e) {
+    console.error(e);
+    document.getElementById("hero-report").innerHTML =
+      `<div class="alert alert-warn">Dados ainda não gerados. Execute o script Python primeiro.</div>`;
+  }
+}
+
+/* ── KPIs ────────────────────────────────────────────────────────────────── */
+
+function renderKPIs() {
+  const r = S.report;
+  setText("kpi-total", nFmt.format(r.total_candidates));
+  setText("kpi-with",  nFmt.format(r.with_plan));
+  setText("kpi-pct",   pFmt.format(r.pct_with_plan) + "%");
+  const scan = r.extraction?.empty_scan || 0;
+  setText("kpi-scan",  nFmt.format(scan));
+  // plágio vem depois
+}
+
+function setText(id, val) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = val;
+}
+
+function renderHeroReport() {
+  const r = S.report;
+  const el = document.getElementById("hero-report");
+  const d  = new Date(r.generated_at);
+  const fmt = new Intl.DateTimeFormat("pt-BR", {dateStyle:"short",timeStyle:"short"});
+  el.innerHTML = `
+    <div style="font-size:.8rem;color:var(--muted)">
+      <strong style="color:var(--ink)">Atualizado em:</strong><br>
+      ${fmt.format(d)}<br><br>
+      <strong style="color:var(--ink)">Fonte:</strong><br>
+      TSE – Dados Abertos<br>
+      candidatos 2024
+    </div>`;
+}
+
+/* ── popular selects de filtros ──────────────────────────────────────────── */
+
+function populateFilters() {
+  const meta = S.metadata;
+
+  // UFs únicas
+  const ufs = [...new Set(meta.map(c => c.uf).filter(Boolean))].sort();
+  // Partidos únicos
+  const parties = [...new Set(meta.map(c => c.partido).filter(Boolean))].sort();
+
+  // Buscador
+  fillSelect("kw-uf",    ufs,     true);
+  fillSelect("kw-party", parties, true);
+
+  // Tema filter
+  fillSelect("tr-uf",    ufs,     true);
+  fillSelect("tr-party", parties, true);
+
+  // Plágio
+  fillSelect("plag-uf",    ufs,     true);
+  fillSelect("plag-party", parties, true);
+
+  // VS tema
+  fillThemeSelect("vs-theme");
+
+  // Preencher selects de UF de comparação de estado nas outras abas
+  STATES.forEach(uf => {
+    ["kw-uf","tr-uf","plag-uf"].forEach(id => {
+      // já preenchido acima — noop
+    });
+  });
+}
+
+function fillSelect(id, options, blank = false) {
+  const sel = document.getElementById(id);
+  if (!sel) return;
+  if (blank) sel.innerHTML = `<option value="">Todos</option>`;
+  options.forEach(v => {
+    const opt = document.createElement("option");
+    opt.value = v; opt.textContent = v;
+    sel.appendChild(opt);
+  });
+}
+
+function fillThemeSelect(id) {
+  const sel = document.getElementById(id);
+  if (!sel || !S.themes) return;
+  sel.innerHTML = `<option value="">Texto completo</option>`;
+  S.themes.forEach(t => {
+    const opt = document.createElement("option");
+    opt.value = t.slug; opt.textContent = t.name;
+    sel.appendChild(opt);
+  });
+}
+
+/* ── Panorama: cobertura por estado ──────────────────────────────────────── */
+
+function renderStateCoverage() {
+  const el = document.getElementById("state-coverage");
+  if (!S.report?.by_state) return;
+  const rows = Object.entries(S.report.by_state)
+    .sort((a, b) => b[1].pct - a[1].pct);
+
+  el.innerHTML = rows.map(([uf, d]) => `
+    <div class="prog-row">
+      <span>${uf}</span>
+      <div class="prog-bar-bg">
+        <div class="prog-bar-fill" style="width:${d.pct}%"></div>
+      </div>
+      <span class="prog-pct">${pFmt.format(d.pct)}%</span>
+    </div>`).join("");
+}
+
+/* ── Panorama: gráfico temas ──────────────────────────────────────────────── */
+
+function renderThemeBarChart() {
+  const ctx = document.getElementById("chart-themes");
+  if (!ctx || !S.themes) return;
+  const sorted = [...S.themes].sort((a, b) => b.count - a.count).slice(0, 20);
+  new Chart(ctx, {
+    type: "bar",
+    data: {
+      labels: sorted.map(t => t.name),
+      datasets: [{
+        data: sorted.map(t => t.count),
+        backgroundColor: "#2660c6cc",
+        borderRadius: 6,
+      }],
+    },
+    options: {
+      indexAxis: "y",
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { ticks: { font: { size: 11 } } },
+        y: { ticks: { font: { size: 11 } } },
+      },
+    },
+  });
+}
+
+/* ── Panorama: gráfico partidos ───────────────────────────────────────────── */
+
+function renderPartyBarChart() {
+  const ctx = document.getElementById("chart-parties");
+  if (!ctx || !S.metadata) return;
+  const cnt = {};
+  S.metadata.forEach(c => {
+    if (!c.has_plan) return;
+    cnt[c.partido] = (cnt[c.partido] || 0) + 1;
+  });
+  const sorted = Object.entries(cnt).sort((a,b) => b[1]-a[1]).slice(0, 25);
+  new Chart(ctx, {
+    type: "bar",
+    data: {
+      labels: sorted.map(e => e[0]),
+      datasets: [{
+        data: sorted.map(e => e[1]),
+        backgroundColor: "#c17c3fcc",
+        borderRadius: 6,
+      }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: { y: { ticks: { font: { size: 11 } } } },
+    },
+  });
+}
+
+/* ── Buscador: grade de temas ─────────────────────────────────────────────── */
+
+function renderThemeGrid() {
+  const el = document.getElementById("theme-grid");
+  if (!S.themes) return;
+  el.innerHTML = S.themes
+    .sort((a,b) => b.count - a.count)
+    .map(t => `
+      <button class="theme-card" data-slug="${esc(t.slug)}" data-name="${esc(t.name)}">
+        <div class="tc-name">${esc(t.name)}</div>
+        <div class="tc-cnt">${nFmt.format(t.count)} candidatos</div>
+      </button>`).join("");
+
+  el.querySelectorAll(".theme-card").forEach(card => {
+    card.addEventListener("click", () => {
+      el.querySelectorAll(".theme-card").forEach(c => c.classList.remove("active"));
+      card.classList.add("active");
+      loadTheme(card.dataset.slug, card.dataset.name);
+    });
+  });
+}
+
+async function loadTheme(slug, name) {
+  const panel = document.getElementById("theme-results-panel");
+  const title = document.getElementById("theme-results-title");
+  panel.style.display = "grid";
+  title.textContent = `Tema: ${name}`;
+
+  document.getElementById("tr-results").innerHTML = spinner();
+  document.getElementById("tr-status").textContent = "";
+  document.getElementById("tr-pager").innerHTML = "";
+
+  if (!S.themeCache[slug]) {
+    try {
+      S.themeCache[slug] = await fetchJSON(`${DATA}/themes/${slug}.json`);
+    } catch {
+      document.getElementById("tr-results").innerHTML =
+        `<div class="no-data">Dados do tema não encontrados.</div>`;
+      return;
+    }
+  }
+
+  S.activeTheme    = slug;
+  S.activeThemeAll = S.themeCache[slug].candidates || [];
+  S.trPage         = 0;
+
+  // popular filtros de UF/partido com os valores presentes neste tema
+  const ths_ufs     = [...new Set(S.activeThemeAll.map(c => c.uf).filter(Boolean))].sort();
+  const ths_parties = [...new Set(S.activeThemeAll.map(c => c.partido).filter(Boolean))].sort();
+  fillSelect("tr-uf",    ths_ufs,     true);
+  fillSelect("tr-party", ths_parties, true);
+
+  applyThemeFilter();
+  panel.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function applyThemeFilter() {
+  const uf     = document.getElementById("tr-uf").value;
+  const party  = document.getElementById("tr-party").value;
+  const city   = norm(document.getElementById("tr-city").value);
+
+  S.activeThemeFlt = S.activeThemeAll.filter(c =>
+    (!uf    || c.uf      === uf) &&
+    (!party || c.partido === party) &&
+    (!city  || norm(c.municipio || "").includes(city))
+  );
+  S.trPage = 0;
+  renderThemeResults();
+}
+
+function renderThemeResults() {
+  const el   = document.getElementById("tr-results");
+  const data = S.activeThemeFlt;
+  const page = S.trPage;
+  const slice = data.slice(page * PAGE_SIZE, (page+1) * PAGE_SIZE);
+
+  document.getElementById("tr-status").textContent =
+    `${nFmt.format(data.length)} candidatos encontrados`;
+
+  if (!slice.length) {
+    el.innerHTML = `<div class="no-data">Nenhum candidato neste filtro.</div>`;
+    document.getElementById("tr-pager").innerHTML = "";
+    return;
+  }
+
+  el.innerHTML = `
+    <div class="tbl-wrap">
+      <table>
+        <thead><tr>
+          <th>Nome</th><th>Partido</th><th>Município</th><th>UF</th><th>Trecho</th>
+        </tr></thead>
+        <tbody>
+          ${slice.map(c => `
+            <tr>
+              <td>${esc(c.nome)}</td>
+              <td><span class="pill">${esc(c.partido)}</span></td>
+              <td>${esc(c.municipio)}</td>
+              <td>${esc(c.uf)}</td>
+              <td><div class="snippet">${esc(c.snippet || "")}</div></td>
+            </tr>`).join("")}
+        </tbody>
+      </table>
+    </div>`;
+
+  renderPager("tr-pager", data.length, page, p => { S.trPage = p; renderThemeResults(); });
+}
+
+document.getElementById("tr-filter-btn").addEventListener("click", applyThemeFilter);
+
+/* ── Buscador: busca por palavra-chave ───────────────────────────────────── */
+
+function setupBuscador() {
+  document.getElementById("kw-search-btn").addEventListener("click", runKwSearch);
+  document.getElementById("kw-input").addEventListener("keydown", e => {
+    if (e.key === "Enter") runKwSearch();
+  });
+}
+
+async function runKwSearch() {
+  const kw    = document.getElementById("kw-input").value.trim();
+  const uf    = document.getElementById("kw-uf").value;
+  const party = document.getElementById("kw-party").value;
+  const city  = norm(document.getElementById("kw-city").value);
+
+  if (!kw) {
+    document.getElementById("kw-status").textContent = "Digite uma palavra-chave.";
+    return;
+  }
+
+  const kwn = norm(kw);
+  document.getElementById("kw-results").innerHTML = spinner();
+  document.getElementById("kw-status").textContent = "";
+  document.getElementById("kw-pager").innerHTML = "";
+
+  // Se UF selecionado, carregamos dados completos com snippet daquele estado
+  let pool;
+  if (uf) {
+    pool = await loadStateData(uf);
+  } else {
+    // Busca no metadata (usa snippet curto – comportamento esperado sem filtro de UF)
+    pool = S.metadata.map(c => ({
+      ...c,
+      snippet: c.text_snippet || "",
+    }));
+  }
+
+  // Filtrar
+  const kwRe = new RegExp(kwn, "i");
+  S.kwResults = pool.filter(c => {
+    if (!c.has_plan) return false;
+    if (party && c.partido !== party) return false;
+    if (city  && !norm(c.municipio || "").includes(city)) return false;
+    // Busca no snippet/texto disponível
+    const haystack = norm(c.snippet || "") + " " + norm(c.nome || "");
+    return haystack.includes(kwn);
+  });
+
+  S.kwPage = 0;
+  renderKwResults(kw);
+}
+
+function renderKwResults(kw = "") {
+  const el   = document.getElementById("kw-results");
+  const data = S.kwResults;
+  const page = S.kwPage;
+  const slice = data.slice(page * PAGE_SIZE, (page+1) * PAGE_SIZE);
+
+  document.getElementById("kw-status").textContent =
+    `${nFmt.format(data.length)} candidatos encontrados`;
+
+  if (!slice.length) {
+    el.innerHTML = `<div class="no-data">Nenhum resultado para esta busca.</div>`;
+    document.getElementById("kw-pager").innerHTML = "";
+    return;
+  }
+
+  el.innerHTML = `
+    <div class="tbl-wrap">
+      <table>
+        <thead><tr>
+          <th>Nome</th><th>Partido</th><th>Município</th><th>UF</th><th>Trecho</th>
+        </tr></thead>
+        <tbody>
+          ${slice.map(c => {
+            const snip = extractSnippet(c.snippet || "", kw);
+            return `<tr>
+              <td>${esc(c.nome_urna || c.nome)}</td>
+              <td><span class="pill">${esc(c.partido)}</span></td>
+              <td>${esc(c.municipio)}</td>
+              <td>${esc(c.uf)}</td>
+              <td><div class="snippet">${highlight(snip, kw)}</div></td>
+            </tr>`;
+          }).join("")}
+        </tbody>
+      </table>
+    </div>`;
+
+  renderPager("kw-pager", data.length, page, p => { S.kwPage = p; renderKwResults(kw); });
+}
+
+/* ── loader de estado ────────────────────────────────────────────────────── */
+
+async function loadStateData(uf) {
+  if (!S.stateCache[uf]) {
+    try {
+      S.stateCache[uf] = await fetchJSON(`${DATA}/states/${uf}.json`);
+    } catch {
+      S.stateCache[uf] = [];
+    }
+  }
+  return S.stateCache[uf];
+}
+
+async function loadCandidateText(id) {
+  if (!S.candCache[id]) {
+    try {
+      S.candCache[id] = await fetchJSON(`${DATA}/candidates/${id}.json`);
+    } catch {
+      S.candCache[id] = null;
+    }
+  }
+  return S.candCache[id];
+}
+
+/* ── Partidos ─────────────────────────────────────────────────────────────── */
+
+async function loadParties() {
+  try {
+    S.parties = await fetchJSON(`${DATA}/parties.json`);
+    S.partyData = S.parties;
+    populatePartySelects();
+  } catch (e) {
+    document.getElementById("party-results").innerHTML =
+      `<div class="no-data">Dados de partidos não encontrados.</div>`;
+  }
+}
+
+function setupPartidosTab() {
+  document.getElementById("party-compare-btn").addEventListener("click", runPartyCompare);
+}
+
+function populatePartySelects() {
+  if (!S.parties) return;
+  const parties = Object.keys(S.parties).sort();
+  ["party-a","party-b"].forEach(id => {
+    const sel = document.getElementById(id);
+    const blank = id === "party-b" ? `<option value="">— nenhum —</option>` : `<option value="">selecione…</option>`;
+    sel.innerHTML = blank;
+    parties.forEach(p => {
+      const opt = document.createElement("option");
+      opt.value = p; opt.textContent = p + ` (${nFmt.format(S.parties[p].total)})`;
+      sel.appendChild(opt);
+    });
+  });
+
+  // Preencher select de temas
+  const tsel = document.getElementById("party-theme");
+  tsel.innerHTML = `<option value="">selecione…</option>`;
+  if (S.themes) {
+    S.themes.forEach(t => {
+      const opt = document.createElement("option");
+      opt.value = t.slug; opt.textContent = t.name;
+      tsel.appendChild(opt);
+    });
+  }
+}
+
+function runPartyCompare() {
+  if (!S.parties) {
+    document.getElementById("party-results").innerHTML =
+      `<div class="alert alert-warn">Clique na aba "Por partido" para carregar os dados.</div>`;
+    return;
+  }
+  const pA    = document.getElementById("party-a").value;
+  const pB    = document.getElementById("party-b").value;
+  const theme = document.getElementById("party-theme").value;
+
+  if (!pA) {
+    document.getElementById("party-results").innerHTML =
+      `<div class="alert alert-warn">Selecione ao menos o Partido A.</div>`;
+    return;
+  }
+
+  const el = document.getElementById("party-results");
+  const cols = [pA, pB].filter(Boolean).map(p => renderPartyCol(p, theme));
+
+  el.innerHTML = `<div class="party-compare-grid">${cols.join("")}</div>`;
+}
+
+function renderPartyCol(party, themeSlug) {
+  const d = S.parties[party];
+  if (!d) return `<div class="compare-col"><div class="no-data">Partido não encontrado.</div></div>`;
+
+  // Ordenar temas por contagem
+  const themesSorted = Object.entries(d.themes || {}).sort((a,b) => b[1]-a[1]);
+
+  let themeHighlight = "";
+  if (themeSlug && S.themeCache[themeSlug]) {
+    // Candidatos deste partido que mencionam o tema
+    const tname = (S.themes || []).find(t => t.slug === themeSlug)?.name || themeSlug;
+    const cands = (S.themeCache[themeSlug].candidates || [])
+      .filter(c => c.partido === party).slice(0, 6);
+    themeHighlight = `
+      <div class="theme-section">
+        <div class="theme-section-title">Tema: ${esc(tname)}</div>
+        ${cands.length
+          ? cands.map(c => `
+              <div style="font-size:.82rem;margin-bottom:.4rem">
+                <strong>${esc(c.nome)}</strong> – ${esc(c.municipio)}/${esc(c.uf)}<br>
+                <span class="snippet">${esc(c.snippet || "").slice(0,200)}</span>
+              </div>`).join("")
+          : `<span class="snippet">Nenhum candidato deste partido menciona o tema selecionado.</span>`
+        }
+      </div>`;
+  }
+
+  return `
+    <div class="compare-col">
+      <div class="compare-header">${esc(party)}</div>
+      <div style="font-size:.82rem;color:var(--muted);margin-bottom:.7rem">
+        ${nFmt.format(d.total)} candidatos ·
+        ${nFmt.format(d.with_plan)} com plano (${pFmt.format(d.pct_plan)}%)
+      </div>
+      ${themeHighlight}
+      <div class="panel-sub" style="margin-bottom:.4rem">Temas mais citados:</div>
+      <div class="party-theme-list">
+        ${themesSorted.slice(0,15).map(([th, cnt]) => `
+          <div class="ptl-row">
+            <span>${esc(th)}</span>
+            <span class="ptl-cnt">${nFmt.format(cnt)}</span>
+          </div>`).join("")}
+      </div>
+      <div class="panel-sub" style="margin-top:.7rem;margin-bottom:.4rem">Exemplos de candidatos:</div>
+      ${(d.cands_sample || []).slice(0,5).map(c =>
+        `<div style="font-size:.82rem;margin-bottom:.3rem">
+          ${esc(c.nome)} – ${esc(c.municipio)}/${esc(c.uf)}
+         </div>`).join("")}
+    </div>`;
+}
+
+/* ── VS: candidato vs candidato ──────────────────────────────────────────── */
+
+function setupVS() {
+  setupVSInput("a");
+  setupVSInput("b");
+  document.getElementById("vs-compare-btn").addEventListener("click", runVS);
+  fillThemeSelect("vs-theme");
+}
+
+function setupVSInput(side) {
+  const input  = document.getElementById(`vs-${side}-input`);
+  const list   = document.getElementById(`vs-${side}-list`);
+  const chosen = document.getElementById(`vs-${side}-chosen`);
+
+  input.addEventListener("input", () => {
+    const q = norm(input.value.trim());
+    if (q.length < 2) { list.innerHTML = ""; return; }
+
+    const matches = (S.metadata || [])
+      .filter(c => c.has_plan && (norm(c.nome).includes(q) || norm(c.nome_urna||"").includes(q) || norm(c.municipio||"").includes(q)))
+      .slice(0, 8);
+
+    list.innerHTML = matches.map(c => `
+      <button class="theme-card" style="width:100%;margin-bottom:.3rem"
+        data-id="${esc(c.id)}"
+        data-nome="${esc(c.nome_urna||c.nome)}"
+        data-partido="${esc(c.partido)}"
+        data-municipio="${esc(c.municipio)}"
+        data-uf="${esc(c.uf)}">
+        <div class="tc-name">${esc(c.nome_urna||c.nome)}</div>
+        <div class="tc-cnt">${esc(c.partido)} · ${esc(c.municipio)}/${esc(c.uf)}</div>
+      </button>`).join("");
+
+    list.querySelectorAll("button").forEach(btn => {
+      btn.addEventListener("click", () => {
+        S[`vs${side.toUpperCase()}`] = btn.dataset;
+        chosen.style.display = "inline-block";
+        chosen.textContent   = `✓ ${btn.dataset.nome} (${btn.dataset.municipio}/${btn.dataset.uf})`;
+        list.innerHTML = "";
+        input.value = "";
+      });
+    });
+  });
+}
+
+async function runVS() {
+  const vsEl = document.getElementById("vs-results");
+  const cA   = S.vsA;
+  const cB   = S.vsB;
+
+  if (!cA || !cB) {
+    alert("Selecione os dois candidatos.");
+    return;
+  }
+
+  vsEl.style.display = "none";
+  document.getElementById("vs-a-header").textContent = `${cA.nome} (${cA.municipio}/${cA.uf})`;
+  document.getElementById("vs-b-header").textContent = `${cB.nome} (${cB.municipio}/${cB.uf})`;
+  document.getElementById("vs-a-text").textContent = "carregando…";
+  document.getElementById("vs-b-text").textContent = "carregando…";
+  vsEl.style.display = "grid";
+
+  const [dataA, dataB] = await Promise.all([
+    loadCandidateText(cA.id),
+    loadCandidateText(cB.id),
+  ]);
+
+  const themeSlug = document.getElementById("vs-theme").value;
+
+  if (themeSlug && S.themes) {
+    // Mostrar só trechos do tema selecionado
+    if (!S.themeCache[themeSlug]) {
+      const slug = themeSlug;
+      try { S.themeCache[slug] = await fetchJSON(`${DATA}/themes/${slug}.json`); } catch {}
+    }
+    const tname = S.themes.find(t => t.slug === themeSlug)?.name || themeSlug;
+    const keywords = S.themeCache[themeSlug]?.keywords || [];
+
+    document.getElementById("vs-a-text").textContent =
+      extractThemeText(dataA?.text || "", keywords) || "(Sem menção a este tema)";
+    document.getElementById("vs-b-text").textContent =
+      extractThemeText(dataB?.text || "", keywords) || "(Sem menção a este tema)";
+  } else {
+    document.getElementById("vs-a-text").textContent = dataA?.text || "(Sem plano disponível)";
+    document.getElementById("vs-b-text").textContent = dataB?.text || "(Sem plano disponível)";
+  }
+}
+
+function extractThemeText(text, keywords) {
+  if (!text) return "";
+  const tn = norm(text);
+  const chunks = [];
+  for (const kw of keywords) {
+    const kwn = norm(kw);
+    let idx = 0;
+    while (true) {
+      const pos = tn.indexOf(kwn, idx);
+      if (pos === -1) break;
+      const s = Math.max(0, pos - 60);
+      const e = Math.min(text.length, pos + kwn.length + 200);
+      chunks.push("…" + text.slice(s, e).trim() + "…");
+      idx = pos + 1;
+      if (chunks.length >= 5) break;
+    }
+    if (chunks.length >= 5) break;
+  }
+  return chunks.join("\n\n") || "";
+}
+
+/* ── Plágio ───────────────────────────────────────────────────────────────── */
+
+async function loadPlagiarism() {
+  document.getElementById("plag-list").innerHTML = spinner();
+  try {
+    S.plagiarism = await fetchJSON(`${DATA}/plagiarism.json`);
+    renderPlagiarism();
+    setupPlagFilter();
+  } catch (e) {
+    document.getElementById("plag-list").innerHTML =
+      `<div class="no-data">Dados de plágio não encontrados. Execute o script Python primeiro.</div>`;
+  }
+}
+
+function renderPlagiarism() {
+  const p = S.plagiarism;
+  if (!p) return;
+
+  // KPIs de plágio
+  document.getElementById("kpi-plag").textContent = pFmt.format(p.pct_with_copies) + "%";
+  document.getElementById("plag-kpis").innerHTML = `
+    <div class="kpi">
+      <div class="kpi-val accent">${nFmt.format(p.total_analyzed)}</div>
+      <div class="kpi-lbl">planos analisados</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-val warn">${nFmt.format(p.candidates_with_copies)}</div>
+      <div class="kpi-lbl">candidatos com trechos copiados</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-val warn">${pFmt.format(p.pct_with_copies)}%</div>
+      <div class="kpi-lbl">do total com plano</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-val">${nFmt.format(p.unique_shared_phrases)}</div>
+      <div class="kpi-lbl">trechos únicos copiados</div>
+    </div>`;
+
+  S.plagFiltered = p.top_phrases || [];
+  S.plagPage = 0;
+  renderPlagList();
+  renderPlagCandTable();
+}
+
+function setupPlagFilter() {
+  document.getElementById("plag-filter-btn").addEventListener("click", applyPlagFilter);
+}
+
+function applyPlagFilter() {
+  const uf      = document.getElementById("plag-uf").value;
+  const party   = document.getElementById("plag-party").value;
+  const minVal  = parseInt(document.getElementById("plag-min").value) || 3;
+
+  if (!S.plagiarism) return;
+
+  S.plagFiltered = (S.plagiarism.top_phrases || []).filter(ph => {
+    if (ph.count < minVal) return false;
+    if (!uf && !party) return true;
+    // verificar se algum exemplo bate com os filtros
+    return (ph.examples || []).some(ex =>
+      (!uf    || ex.uf      === uf) &&
+      (!party || ex.partido === party)
+    );
+  });
+
+  S.plagPage = 0;
+  renderPlagList();
+}
+
+function renderPlagList() {
+  const el    = document.getElementById("plag-list");
+  const data  = S.plagFiltered;
+  const page  = S.plagPage;
+  const slice = data.slice(page * PAGE_SIZE, (page+1) * PAGE_SIZE);
+
+  if (!slice.length) {
+    el.innerHTML = `<div class="no-data">Nenhum trecho encontrado com estes filtros.</div>`;
+    document.getElementById("plag-pager").innerHTML = "";
+    return;
+  }
+
+  el.innerHTML = slice.map((ph, i) => `
+    <div class="plag-phrase">
+      <div class="plag-phrase-text">"${esc(ph.phrase)}"</div>
+      <span class="plag-cnt">
+        Copiado por ${nFmt.format(ph.count)} candidatos
+      </span>
+      <div class="plag-examples">
+        ${(ph.examples || []).slice(0,4).map(ex => `
+          <div class="plag-ex">
+            <strong>${esc(ex.nome)} · ${esc(ex.partido)} · ${esc(ex.municipio)}/${esc(ex.uf)}</strong>
+            "…${esc(ex.context || "").slice(0,250)}…"
+          </div>`).join("")}
+        ${ph.count > 4
+          ? `<div style="font-size:.78rem;color:var(--muted)">
+               + ${nFmt.format(ph.count - 4)} outros candidatos
+             </div>` : ""}
+      </div>
+    </div>`).join("");
+
+  renderPager("plag-pager", data.length, page, p => { S.plagPage = p; renderPlagList(); });
+}
+
+function renderPlagCandTable() {
+  const el = document.getElementById("plag-cands-table");
+  if (!S.plagiarism) return;
+
+  // Contar cópias por candidato
+  const copyCounts = {};
+  (S.plagiarism.top_phrases || []).forEach(ph => {
+    (ph.cand_ids || []).forEach(id => {
+      copyCounts[id] = (copyCounts[id] || 0) + 1;
+    });
+  });
+
+  // Enriquecer com metadata
+  const metaMap = {};
+  (S.metadata || []).forEach(c => { metaMap[c.id] = c; });
+
+  const rows = Object.entries(copyCounts)
+    .sort((a,b) => b[1]-a[1])
+    .slice(0, 30)
+    .map(([id, cnt]) => {
+      const c = metaMap[id] || { nome:"?", partido:"?", municipio:"?", uf:"?" };
+      return { id, cnt, ...c };
+    });
+
+  if (!rows.length) {
+    el.innerHTML = `<div class="no-data">Sem dados.</div>`;
+    return;
+  }
+
+  el.innerHTML = `
+    <div class="tbl-wrap">
+      <table>
+        <thead><tr>
+          <th>#</th><th>Nome</th><th>Partido</th><th>Município</th><th>UF</th>
+          <th>Trechos copiados detectados</th>
+        </tr></thead>
+        <tbody>
+          ${rows.map((r,i) => `
+            <tr>
+              <td>${i+1}</td>
+              <td>${esc(r.nome_urna||r.nome)}</td>
+              <td><span class="pill">${esc(r.partido)}</span></td>
+              <td>${esc(r.municipio)}</td>
+              <td>${esc(r.uf)}</td>
+              <td><span class="pill warn">${nFmt.format(r.cnt)}</span></td>
+            </tr>`).join("")}
+        </tbody>
+      </table>
+    </div>`;
+}
+
+/* ── paginação genérica ───────────────────────────────────────────────────── */
+
+function renderPager(elId, total, currentPage, onPage) {
+  const el     = document.getElementById(elId);
+  const pages  = Math.ceil(total / PAGE_SIZE);
+  if (pages <= 1) { el.innerHTML = ""; return; }
+
+  const MAX_BTNS = 7;
+  let start = Math.max(0, currentPage - 3);
+  let end   = Math.min(pages, start + MAX_BTNS);
+  if (end - start < MAX_BTNS) start = Math.max(0, end - MAX_BTNS);
+
+  const btns = [];
+  if (currentPage > 0)
+    btns.push(`<button data-p="${currentPage-1}">‹</button>`);
+
+  for (let i = start; i < end; i++)
+    btns.push(`<button data-p="${i}" class="${i===currentPage?"active":""}">${i+1}</button>`);
+
+  if (currentPage < pages - 1)
+    btns.push(`<button data-p="${currentPage+1}">›</button>`);
+
+  btns.push(`<span>${nFmt.format(total)} resultados · pág. ${currentPage+1}/${pages}</span>`);
+
+  el.innerHTML = btns.join("");
+  el.querySelectorAll("button[data-p]").forEach(btn => {
+    btn.addEventListener("click", () => onPage(+btn.dataset.p));
+  });
+}
+
+/* ── arranque ────────────────────────────────────────────────────────────── */
+
+init();
+
+})();

--- a/planos-governo-dashboard/index.html
+++ b/planos-governo-dashboard/index.html
@@ -1,0 +1,414 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Planos de governo 2024 – Eleições Municipais</title>
+  <meta name="description" content="Busca e análise dos planos de governo de candidatos às eleições municipais brasileiras de 2024.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Albert+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+  <style>
+    :root {
+      --bg:          #f5f5f2;
+      --panel:       #fffefb;
+      --ink:         #2f2f2d;
+      --muted:       #65645f;
+      --line:        #d6d4cc;
+      --accent:      #2660c6;
+      --accent-s:    #dde9ff;
+      --accent2:     #c17c3f;
+      --accent2-s:   #f5e9dc;
+      --good:        #2f7d59;
+      --bad:         #9a2e2e;
+      --warn:        #9b6a00;
+      --warn-s:      #fdf3d0;
+      --shadow:      0 6px 22px rgba(44,41,35,.08);
+      --radius:      14px;
+    }
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:"Albert Sans",sans-serif;background:linear-gradient(180deg,#f7f6f2 0%,#efede7 100%);color:var(--ink);min-height:100vh}
+
+    /* ── layout ──────────────────────────────────────────────────────── */
+    .page{width:min(1240px,96vw);margin:1.2rem auto 3rem;display:grid;gap:.9rem}
+
+    /* ── nav ──────────────────────────────────────────────────────────── */
+    .breadcrumb{display:flex;gap:.4rem;align-items:center;font-size:.82rem;color:var(--muted)}
+    .breadcrumb a{color:var(--accent);text-decoration:none}
+    .breadcrumb a:hover{text-decoration:underline}
+
+    /* ── hero ──────────────────────────────────────────────────────────── */
+    .hero{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:1.4rem 1.6rem;display:grid;gap:.8rem}
+    .hero-row{display:flex;flex-wrap:wrap;gap:.8rem;align-items:flex-start}
+    .hero-text{flex:1;min-width:200px}
+    h1{font-size:clamp(1.25rem,2.2vw,2rem);line-height:1.2;font-weight:700}
+    .tag{display:inline-block;padding:.18rem .55rem;border-radius:999px;font-size:.75rem;font-weight:600;background:var(--accent-s);color:var(--accent)}
+    .sub{color:var(--muted);font-size:.93rem;line-height:1.55}
+
+    /* ── KPI strip ────────────────────────────────────────────────────── */
+    .kpi-row{display:flex;flex-wrap:wrap;gap:.6rem}
+    .kpi{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:.8rem 1rem;flex:1;min-width:130px}
+    .kpi-val{font-size:1.7rem;font-weight:700;line-height:1;font-family:"IBM Plex Mono",monospace}
+    .kpi-lbl{font-size:.78rem;color:var(--muted);margin-top:.3rem}
+    .kpi-val.accent{color:var(--accent)}
+    .kpi-val.good{color:var(--good)}
+    .kpi-val.warn{color:var(--warn)}
+
+    /* ── tabs ──────────────────────────────────────────────────────────── */
+    .tab-bar{display:flex;gap:.35rem;flex-wrap:wrap;border-bottom:2px solid var(--line);padding-bottom:.5rem}
+    .tab-btn{border:none;background:none;cursor:pointer;padding:.45rem .9rem;border-radius:8px 8px 0 0;font-size:.9rem;font-weight:600;color:var(--muted);font-family:inherit;transition:all .15s}
+    .tab-btn:hover{background:var(--accent-s);color:var(--accent)}
+    .tab-btn.active{background:var(--accent);color:#fff}
+    .tab-pane{display:none}
+    .tab-pane.active{display:grid;gap:1rem}
+
+    /* ── panel ──────────────────────────────────────────────────────────── */
+    .panel{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:1.2rem 1.4rem;display:grid;gap:.9rem}
+    .panel-title{font-size:1rem;font-weight:700}
+    .panel-sub{font-size:.82rem;color:var(--muted)}
+
+    /* ── two-col ──────────────────────────────────────────────────────── */
+    .two-col{display:grid;grid-template-columns:1fr 1fr;gap:.9rem}
+    @media(max-width:700px){.two-col{grid-template-columns:1fr}}
+
+    /* ── form controls ───────────────────────────────────────────────── */
+    .filter-row{display:flex;flex-wrap:wrap;gap:.6rem;align-items:flex-end}
+    label{font-size:.82rem;font-weight:600;display:flex;flex-direction:column;gap:.3rem}
+    input[type=text],select{
+      border:1px solid var(--line);border-radius:8px;padding:.45rem .7rem;
+      font-size:.88rem;font-family:inherit;background:#fff;color:var(--ink);
+      outline:none;transition:border .15s}
+    input[type=text]:focus,select:focus{border-color:var(--accent)}
+    input[type=text]{width:260px}
+    select{min-width:140px}
+    .btn{border:none;cursor:pointer;border-radius:8px;padding:.48rem 1rem;
+      font-size:.88rem;font-weight:700;font-family:inherit;transition:all .15s;white-space:nowrap}
+    .btn-primary{background:var(--accent);color:#fff}
+    .btn-primary:hover{filter:brightness(1.15)}
+    .btn-ghost{background:var(--accent-s);color:var(--accent)}
+    .btn-ghost:hover{background:var(--accent);color:#fff}
+
+    /* ── table ───────────────────────────────────────────────────────── */
+    .tbl-wrap{overflow-x:auto;border-radius:10px;border:1px solid var(--line)}
+    table{width:100%;border-collapse:collapse;font-size:.86rem}
+    thead th{background:#f0efe9;padding:.55rem .8rem;text-align:left;font-weight:600;font-size:.8rem;color:var(--muted);border-bottom:1px solid var(--line)}
+    tbody tr{border-bottom:1px solid #eee}
+    tbody tr:last-child{border-bottom:none}
+    tbody td{padding:.5rem .8rem;vertical-align:top}
+    tbody tr:hover{background:#faf9f5}
+    .snippet{color:var(--muted);font-size:.81rem;margin-top:.2rem;font-style:italic;line-height:1.4}
+    mark{background:#fff3cd;border-radius:3px;padding:0 2px}
+    .pill{display:inline-block;padding:.1rem .42rem;border-radius:999px;font-size:.73rem;font-weight:600;background:var(--accent-s);color:var(--accent)}
+    .pill.warn{background:var(--warn-s);color:var(--warn)}
+    .no-data{color:var(--muted);font-size:.88rem;text-align:center;padding:1.4rem}
+
+    /* ── theme grid ──────────────────────────────────────────────────── */
+    .theme-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:.55rem}
+    .theme-card{border:1px solid var(--line);border-radius:10px;padding:.65rem .8rem;cursor:pointer;background:#fff;transition:all .15s;text-align:left}
+    .theme-card:hover,.theme-card.active{border-color:var(--accent);background:var(--accent-s)}
+    .theme-card .tc-name{font-size:.88rem;font-weight:600}
+    .theme-card .tc-cnt{font-size:.8rem;color:var(--muted);margin-top:.2rem}
+
+    /* ── bar chart ───────────────────────────────────────────────────── */
+    .chart-wrap{position:relative;height:300px}
+
+    /* ── progress bar ────────────────────────────────────────────────── */
+    .prog-row{display:grid;grid-template-columns:90px 1fr 60px;gap:.5rem;align-items:center;font-size:.84rem}
+    .prog-bar-bg{background:#ebe9e2;border-radius:999px;height:9px;overflow:hidden}
+    .prog-bar-fill{height:100%;border-radius:999px;background:var(--accent);transition:width .4s}
+    .prog-pct{color:var(--muted);font-family:"IBM Plex Mono",monospace;font-size:.8rem;text-align:right}
+
+    /* ── compare ──────────────────────────────────────────────────────── */
+    .compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
+    @media(max-width:700px){.compare-grid{grid-template-columns:1fr}}
+    .compare-col{border:1px solid var(--line);border-radius:var(--radius);padding:1rem;background:#fff}
+    .compare-header{font-weight:700;font-size:.95rem;margin-bottom:.6rem;border-bottom:2px solid var(--accent);padding-bottom:.4rem}
+    .compare-text{font-size:.83rem;line-height:1.6;max-height:420px;overflow-y:auto;white-space:pre-wrap;color:#333}
+    .theme-section{margin-bottom:.8rem}
+    .theme-section-title{font-size:.8rem;font-weight:700;color:var(--accent);margin-bottom:.3rem}
+
+    /* ── plagiarism ──────────────────────────────────────────────────── */
+    .plag-phrase{border:1px solid var(--line);border-radius:10px;padding:.8rem 1rem;background:#fff}
+    .plag-phrase-text{font-family:"IBM Plex Mono",monospace;font-size:.82rem;background:#fdf6e3;border-radius:6px;padding:.5rem .7rem;margin-bottom:.6rem;line-height:1.5}
+    .plag-cnt{font-size:.8rem;font-weight:700;color:var(--warn)}
+    .plag-examples{margin-top:.5rem;display:grid;gap:.4rem}
+    .plag-ex{font-size:.8rem;border-left:3px solid var(--accent);padding-left:.6rem;color:var(--muted);line-height:1.45}
+    .plag-ex strong{color:var(--ink);display:block}
+    .plag-list{display:grid;gap:.7rem;max-height:600px;overflow-y:auto}
+
+    /* ── loading / alert ─────────────────────────────────────────────── */
+    .loading{display:flex;align-items:center;gap:.6rem;color:var(--muted);font-size:.9rem;padding:.8rem}
+    .spinner{width:18px;height:18px;border:3px solid var(--line);border-top-color:var(--accent);border-radius:50%;animation:spin .7s linear infinite;flex-shrink:0}
+    @keyframes spin{to{transform:rotate(360deg)}}
+    .alert{border-radius:10px;padding:.7rem 1rem;font-size:.88rem}
+    .alert-warn{background:var(--warn-s);color:var(--warn);border:1px solid #e0c56a}
+    .alert-info{background:var(--accent-s);color:var(--accent);border:1px solid #a0bcf0}
+
+    /* ── pagination ──────────────────────────────────────────────────── */
+    .pager{display:flex;gap:.4rem;align-items:center;flex-wrap:wrap;font-size:.85rem}
+    .pager button{border:1px solid var(--line);border-radius:6px;padding:.3rem .65rem;cursor:pointer;background:#fff;font-family:inherit;font-size:.85rem}
+    .pager button.active{background:var(--accent);color:#fff;border-color:var(--accent)}
+    .pager button:hover:not(.active){background:var(--accent-s)}
+    .pager span{color:var(--muted)}
+
+    /* ── search result count ──────────────────────────────────────────── */
+    .result-info{font-size:.84rem;color:var(--muted)}
+
+    /* ── party compare ────────────────────────────────────────────────── */
+    .party-compare-grid{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
+    @media(max-width:700px){.party-compare-grid{grid-template-columns:1fr}}
+    .party-theme-list{display:grid;gap:.35rem}
+    .ptl-row{display:flex;justify-content:space-between;align-items:center;font-size:.85rem;border-bottom:1px solid #eee;padding:.3rem 0}
+    .ptl-cnt{font-family:"IBM Plex Mono",monospace;font-size:.8rem;color:var(--accent)}
+  </style>
+</head>
+<body>
+
+<div class="page">
+
+  <!-- breadcrumb -->
+  <div class="breadcrumb">
+    <a href="/">luizftoledo.github.io</a>
+    <span>›</span>
+    <span>Planos de governo 2024</span>
+  </div>
+
+  <!-- hero -->
+  <div class="hero">
+    <div class="hero-row">
+      <div class="hero-text">
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:.5rem">
+          <span class="tag">Eleições Municipais 2024</span>
+          <span class="tag" style="background:var(--accent2-s);color:var(--accent2)">TSE – Dados Abertos</span>
+        </div>
+        <h1>Planos de governo dos candidatos</h1>
+        <p class="sub" style="margin-top:.4rem">
+          Busca, análise temática, comparação entre candidatos e detecção de plágio nos planos
+          de governo submetidos ao TSE para as eleições municipais de 2024. Dados extraídos dos
+          PDFs oficiais disponibilizados pelo Tribunal Superior Eleitoral.
+        </p>
+      </div>
+      <div id="hero-report" style="min-width:180px;font-size:.82rem;color:var(--muted)">
+        <div class="loading"><div class="spinner"></div> carregando…</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- KPIs -->
+  <div class="kpi-row">
+    <div class="kpi"><div class="kpi-val accent" id="kpi-total">—</div><div class="kpi-lbl">candidatos a prefeito</div></div>
+    <div class="kpi"><div class="kpi-val good"   id="kpi-with">—</div><div class="kpi-lbl">com plano de governo</div></div>
+    <div class="kpi"><div class="kpi-val"         id="kpi-pct">—</div><div class="kpi-lbl">% apresentaram plano</div></div>
+    <div class="kpi"><div class="kpi-val warn"    id="kpi-scan">—</div><div class="kpi-lbl">PDFs sem texto (scan)</div></div>
+    <div class="kpi"><div class="kpi-val"         id="kpi-plag">—</div><div class="kpi-lbl">% com trechos copiados</div></div>
+  </div>
+
+  <!-- tab bar -->
+  <div class="tab-bar">
+    <button class="tab-btn active" data-tab="panorama">📊 Panorama</button>
+    <button class="tab-btn"        data-tab="busca">🔍 Buscador</button>
+    <button class="tab-btn"        data-tab="partidos">🏛️ Por partido</button>
+    <button class="tab-btn"        data-tab="vs">⚔️ Candidato vs candidato</button>
+    <button class="tab-btn"        data-tab="plagio">📋 Análise de plágio</button>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: PANORAMA                                                      -->
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <div class="tab-pane active" id="tab-panorama">
+
+    <div class="two-col">
+      <div class="panel">
+        <div class="panel-title">Cobertura por estado</div>
+        <div class="panel-sub">% de candidatos com plano de governo enviado ao TSE</div>
+        <div id="state-coverage"></div>
+      </div>
+      <div class="panel">
+        <div class="panel-title">Temas mais citados</div>
+        <div class="panel-sub">Total de candidatos que mencionam cada tema</div>
+        <div class="chart-wrap"><canvas id="chart-themes"></canvas></div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-title">Partidos com mais planos enviados</div>
+      <div class="chart-wrap"><canvas id="chart-parties"></canvas></div>
+    </div>
+
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: BUSCADOR                                                      -->
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <div class="tab-pane" id="tab-busca">
+
+    <!-- keyword search -->
+    <div class="panel">
+      <div class="panel-title">Buscar por palavra-chave</div>
+      <p class="panel-sub">Digite qualquer termo – a busca ignora maiúsculas e acentos. Selecione um estado para busca no texto completo; sem estado a busca usa o resumo.</p>
+      <div class="filter-row">
+        <label>Palavra-chave
+          <input type="text" id="kw-input" placeholder="ex: transporte, hospital…">
+        </label>
+        <label>Estado (UF)
+          <select id="kw-uf">
+            <option value="">Todos</option>
+          </select>
+        </label>
+        <label>Partido
+          <select id="kw-party">
+            <option value="">Todos</option>
+          </select>
+        </label>
+        <label>Município
+          <input type="text" id="kw-city" placeholder="cidade…" style="width:160px">
+        </label>
+        <button class="btn btn-primary" id="kw-search-btn">Buscar</button>
+      </div>
+      <div id="kw-status" class="result-info"></div>
+      <div id="kw-results"></div>
+      <div id="kw-pager" class="pager"></div>
+    </div>
+
+    <!-- pre-selected themes -->
+    <div class="panel">
+      <div class="panel-title">Temas pré-selecionados</div>
+      <p class="panel-sub">Clique em um tema para ver todos os candidatos que o mencionam nos planos.</p>
+      <div id="theme-grid" class="theme-grid">
+        <div class="loading"><div class="spinner"></div> carregando temas…</div>
+      </div>
+    </div>
+
+    <!-- theme results -->
+    <div class="panel" id="theme-results-panel" style="display:none">
+      <div class="panel-title" id="theme-results-title"></div>
+      <div class="filter-row">
+        <label>UF <select id="tr-uf"><option value="">Todos</option></select></label>
+        <label>Partido <select id="tr-party"><option value="">Todos</option></select></label>
+        <label>Município <input type="text" id="tr-city" placeholder="cidade…" style="width:160px"></label>
+        <button class="btn btn-ghost" id="tr-filter-btn">Filtrar</button>
+      </div>
+      <div id="tr-status" class="result-info"></div>
+      <div id="tr-results"></div>
+      <div id="tr-pager" class="pager"></div>
+    </div>
+
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: PARTIDOS                                                      -->
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <div class="tab-pane" id="tab-partidos">
+
+    <div class="panel">
+      <div class="panel-title">Análise por partido</div>
+      <p class="panel-sub">Selecione até dois partidos e um tema para comparar as propostas.</p>
+      <div class="filter-row">
+        <label>Partido A <select id="party-a"><option value="">selecione…</option></select></label>
+        <label>Partido B (opcional) <select id="party-b"><option value="">selecione…</option></select></label>
+        <label>Tema <select id="party-theme"><option value="">selecione…</option></select></label>
+        <button class="btn btn-primary" id="party-compare-btn">Comparar</button>
+      </div>
+    </div>
+
+    <div id="party-results"></div>
+
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: VS                                                            -->
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <div class="tab-pane" id="tab-vs">
+
+    <div class="panel">
+      <div class="panel-title">Candidato vs candidato</div>
+      <p class="panel-sub">Digite o nome ou município de cada candidato para comparar os planos lado a lado. Selecione o tema para ver o trecho específico.</p>
+      <div class="two-col">
+        <div>
+          <label>Candidato A (nome ou município)
+            <input type="text" id="vs-a-input" placeholder="ex: João Silva" style="width:100%">
+          </label>
+          <div id="vs-a-list" style="margin-top:.4rem"></div>
+          <div id="vs-a-chosen" class="pill" style="display:none;margin-top:.4rem"></div>
+        </div>
+        <div>
+          <label>Candidato B (nome ou município)
+            <input type="text" id="vs-b-input" placeholder="ex: Maria Souza" style="width:100%">
+          </label>
+          <div id="vs-b-list" style="margin-top:.4rem"></div>
+          <div id="vs-b-chosen" class="pill" style="display:none;margin-top:.4rem"></div>
+        </div>
+      </div>
+      <div class="filter-row" style="margin-top:.5rem">
+        <label>Filtrar por tema (opcional)
+          <select id="vs-theme"><option value="">Texto completo</option></select>
+        </label>
+        <button class="btn btn-primary" id="vs-compare-btn">Comparar</button>
+      </div>
+    </div>
+
+    <div id="vs-results" class="compare-grid" style="display:none">
+      <div class="compare-col">
+        <div class="compare-header" id="vs-a-header">Candidato A</div>
+        <div class="compare-text" id="vs-a-text"></div>
+      </div>
+      <div class="compare-col">
+        <div class="compare-header" id="vs-b-header">Candidato B</div>
+        <div class="compare-text" id="vs-b-text"></div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: PLÁGIO                                                        -->
+  <!-- ══════════════════════════════════════════════════════════════════ -->
+  <div class="tab-pane" id="tab-plagio">
+
+    <div class="panel">
+      <div class="panel-title">Análise de plágio</div>
+      <p class="panel-sub">
+        Identificação de trechos idênticos (sequências de palavras) compartilhados entre planos de
+        diferentes candidatos. Trechos com 9 ou mais palavras iguais em ≥ 3 candidatos distintos
+        são marcados como cópia.
+      </p>
+      <div id="plag-kpis" class="kpi-row"></div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-title">Filtrar plágio</div>
+      <div class="filter-row">
+        <label>UF <select id="plag-uf"><option value="">Todos</option></select></label>
+        <label>Partido <select id="plag-party"><option value="">Todos</option></select></label>
+        <label>Mín. de candidatos <input type="text" id="plag-min" value="3" style="width:80px"></label>
+        <button class="btn btn-ghost" id="plag-filter-btn">Filtrar</button>
+      </div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-title">Trechos mais copiados</div>
+      <div id="plag-list" class="plag-list">
+        <div class="loading"><div class="spinner"></div> carregando análise de plágio…</div>
+      </div>
+      <div id="plag-pager" class="pager" style="margin-top:.6rem"></div>
+    </div>
+
+    <div class="panel">
+      <div class="panel-title">Candidatos com mais cópias detectadas</div>
+      <div id="plag-cands-table"></div>
+    </div>
+
+  </div>
+
+  <!-- footer -->
+  <div style="font-size:.78rem;color:var(--muted);text-align:center;padding:.5rem 0">
+    Dados: <a href="https://dadosabertos.tse.jus.br/dataset/candidatos-2024" target="_blank" style="color:var(--accent)">TSE – Dados Abertos (candidatos 2024)</a> ·
+    Extração e análise: <a href="/" style="color:var(--accent)">luizftoledo.github.io</a>
+  </div>
+
+</div><!-- .page -->
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/scripts/build_planos_governo_data.py
+++ b/scripts/build_planos_governo_data.py
@@ -1,0 +1,728 @@
+#!/usr/bin/env python3
+"""
+Pipeline de dados: Planos de Governo – Eleições Municipais 2024
+===============================================================
+Baixa os ZIPs do TSE, extrai texto dos PDFs, gera relatório de integridade,
+cruza com dados de candidatos, faz análise textual e exporta JSONs para o
+dashboard estático em planos-governo-dashboard/.
+
+Dependências:
+    pip install requests pandas pdfplumber tqdm
+
+Uso:
+    python scripts/build_planos_governo_data.py
+"""
+
+import os
+import re
+import json
+import math
+import zipfile
+import unicodedata
+from pathlib import Path
+from datetime import datetime
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import requests
+import pandas as pd
+
+try:
+    import pdfplumber
+except ImportError:
+    raise SystemExit("Instale pdfplumber: pip install pdfplumber")
+
+try:
+    from tqdm import tqdm
+    HAS_TQDM = True
+except ImportError:
+    HAS_TQDM = False
+    class tqdm:
+        def __init__(self, iterable=None, **kw): self._it = iterable or []
+        def __iter__(self): return iter(self._it)
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+        def update(self, n=1): pass
+
+# ── Configuração ──────────────────────────────────────────────────────────────
+
+BASE_CDN = "https://cdn.tse.jus.br/estatistica/sead/odsele"
+CAND_URL = f"{BASE_CDN}/consulta_cand/consulta_cand_2024.zip"
+PLAN_URL  = f"{BASE_CDN}/proposta_governo/proposta_governo_2024_{{}}.zip"
+
+STATES = [
+    "AC","AL","AM","AP","BA","CE","DF","ES","GO","MA",
+    "MG","MS","MT","PA","PB","PE","PI","PR","RJ","RN",
+    "RO","RR","RS","SC","SE","SP","TO",
+]
+
+ROOT     = Path(__file__).resolve().parent.parent
+RAW_DIR  = ROOT / "data" / "planos_raw"
+TXT_DIR  = ROOT / "data" / "planos_txt"
+OUT_DIR  = ROOT / "planos-governo-dashboard" / "data"
+
+for d in [RAW_DIR, TXT_DIR, OUT_DIR,
+          OUT_DIR / "states", OUT_DIR / "candidates", OUT_DIR / "themes"]:
+    d.mkdir(parents=True, exist_ok=True)
+
+# ── Stop words (PT-BR) ────────────────────────────────────────────────────────
+
+STOP = set("""
+a ao aos aquela aquelas aquele aqueles aqui as até com como da das de dela
+delas dele deles depois do dos e ela elas ele eles em entre era eram esse
+essa esses essas este esta estes estas eu já lhe lhes lo los mais mas me
+mesmo meu meus minha minhas muito na nas no nos o os ou para pela pelas
+pelo pelos por qual quando que quem se seja sem ser seu seus sua suas
+também te teu teus tinha tu tua tuas um uma uns umas você vocês nos é
+foi foram ter há tem têm só mas não sobre ainda assim através bem cada
+caso cidade deve devem pode podem todas todos todo toda forma ações ação
+além área dentro desde fazer junto maior menos mesmos mesmas neste nesta
+nestes nestas nosso nossa nossos nossas outros outras outro outra parte
+poder primeiro primeira projeto proposta pública público públicos públicas
+sendo suas seus tendo todas todos sendo mediante mediante conforme segundo
+segundo através quanto quais quais cujo cuja cujos cujas onde quando embora
+porém entretanto todavia contudo além disso portanto assim sendo dessa
+desse deste desta nessa nesse neste desta dele dela
+""".split())
+
+# ── Temas pré-definidos ───────────────────────────────────────────────────────
+
+THEMES = {
+    "saúde": [
+        "saúde","hospital","ubs","sus","médico","enfermagem","posto de saúde",
+        "vacina","urgência","emergência","atenção básica","agente de saúde",
+    ],
+    "educação": [
+        "educação","escola","ensino","professor","aluno","creche","infantil",
+        "fundamental","médio","evasão escolar","merenda","alfabetização",
+    ],
+    "saneamento básico": [
+        "saneamento","esgoto","água","abastecimento","tratamento de água",
+        "coleta de lixo","drenagem","córrego","fossas","pluvial",
+    ],
+    "segurança pública": [
+        "segurança","violência","crime","policial","câmera","guarda municipal",
+        "iluminação","monitoramento","patrulhamento","ocorrência",
+    ],
+    "infraestrutura": [
+        "infraestrutura","asfalto","pavimentação","calçada","estrada","ponte",
+        "obras","viaduto","recape","bueiro","drenagem urbana",
+    ],
+    "meio ambiente": [
+        "meio ambiente","ambiental","reciclagem","lixo","resíduos","floresta",
+        "arborização","sustentável","rio","mata ciliar","desmatamento",
+    ],
+    "emprego e renda": [
+        "emprego","trabalho","renda","economia","empreendedorismo","geração de emprego",
+        "microempreendedor","mei","qualificação profissional","capacitação",
+    ],
+    "habitação": [
+        "habitação","moradia","casa","regularização fundiária","sem teto",
+        "aluguel social","conjuntos habitacionais","lotes","terrenos",
+    ],
+    "transporte e mobilidade": [
+        "transporte","ônibus","mobilidade","trânsito","ciclofaixa","bicicleta",
+        "van","lotação","mototáxi","calçada acessível","semáforo",
+    ],
+    "assistência social": [
+        "assistência social","cras","creas","vulnerabilidade","família",
+        "bolsa família","benefício","proteção social","cesta básica","abrigo",
+    ],
+    "cultura, esporte e lazer": [
+        "cultura","esporte","lazer","biblioteca","museu","teatro","quadra",
+        "praça","academia ao ar livre","festival","arena","poliesportivo",
+    ],
+    "tecnologia e inovação": [
+        "tecnologia","digital","inovação","startup","conectividade","wi-fi",
+        "internet","smart city","governo digital","app municipal",
+    ],
+    "agricultura e rural": [
+        "agricultura","agropecuária","produtor rural","campo","cooperativa",
+        "orgânico","irrigação","extensão rural","feira","agroindústria",
+    ],
+    "turismo": [
+        "turismo","turistas","hotel","pousada","patrimônio histórico",
+        "atrativo","roteiro turístico","parque","ecoturismo",
+    ],
+    "mulher": [
+        "mulher","feminino","feminicídio","gênero","machismo",
+        "violência doméstica","maria da penha","casa da mulher","equidade",
+    ],
+    "criança e adolescente": [
+        "criança","adolescente","menor","proteção","eca","conselho tutelar",
+        "creche","brinquedoteca","reforço escolar","vulnerabilidade infantil",
+    ],
+    "idoso": [
+        "idoso","terceira idade","envelhecimento","longevidade",
+        "cuidado ao idoso","aposentado","centro de convivência","ilpi",
+    ],
+    "pessoa com deficiência": [
+        "deficiência","pcd","acessibilidade","inclusão","cadeirante",
+        "libras","braille","rampa","adaptação","rede de apoio",
+    ],
+    "LGBTQIA+": [
+        "lgbtqia","lgbt","diversidade","homofobia","orientação sexual",
+        "transexual","transfobia","direitos lgbtqia",
+    ],
+    "transparência e ética": [
+        "transparência","corrupção","ética","accountability",
+        "prestação de contas","portal da transparência","combate à corrupção",
+    ],
+    "finanças públicas": [
+        "finanças","orçamento","fiscal","tributo","iptu","iss",
+        "dívida pública","responsabilidade fiscal","arrecadação",
+    ],
+    "saúde mental": [
+        "saúde mental","caps","psicológico","psiquiátrico","depressão",
+        "transtorno","bem-estar mental","ansiedade","suicídio",
+    ],
+    "racismo e igualdade racial": [
+        "racismo","racial","negro","afro","quilombola","discriminação racial",
+        "igualdade racial","cotas","comunidades quilombolas",
+    ],
+    "povos indígenas": [
+        "indígena","índio","aldeia","terra indígena","demarcação",
+        "povos originários","cultura indígena",
+    ],
+    "energia e iluminação": [
+        "energia solar","renovável","iluminação pública","led",
+        "energia limpa","eficiência energética","painel solar",
+    ],
+    "combate às drogas": [
+        "drogas","dependência química","tratamento","prevenção","crack",
+        "álcool","comunidade terapêutica","caps ad","vício",
+    ],
+    "gestão pública": [
+        "gestão","eficiência","modernização","desburocratização",
+        "servidor público","concurso","reforma administrativa","planejamento",
+    ],
+    "segurança alimentar": [
+        "segurança alimentar","fome","nutricional","banco de alimentos",
+        "restaurante popular","horta","alimentação saudável",
+    ],
+    "regularização fundiária": [
+        "regularização fundiária","título","propriedade","documentação",
+        "usucapião","lote","habitação irregular","favela",
+    ],
+    "trabalho infantil": [
+        "trabalho infantil","exploração infantil","menor trabalhando",
+        "erradicação do trabalho infantil",
+    ],
+}
+
+
+# ── Utilitários ───────────────────────────────────────────────────────────────
+
+def normalize(text: str) -> str:
+    """Remove acentos, lowercase – para busca sem acento."""
+    return unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii").lower()
+
+
+def download(url: str, dest: Path, label: str = "") -> bool:
+    if dest.exists() and dest.stat().st_size > 0:
+        print(f"  ✓ já baixado: {dest.name}")
+        return True
+    print(f"  ↓ {label or url}")
+    try:
+        r = requests.get(url, timeout=120, stream=True)
+        r.raise_for_status()
+        with open(dest, "wb") as fh:
+            for chunk in r.iter_content(65536):
+                fh.write(chunk)
+        sz = dest.stat().st_size
+        print(f"  ✓ {dest.name}  ({sz/1e6:.1f} MB)")
+        return True
+    except Exception as exc:
+        print(f"  ✗ falha {label}: {exc}")
+        dest.unlink(missing_ok=True)
+        return False
+
+
+def pdf_to_text(pdf_bytes: bytes) -> str:
+    """Extrai texto de bytes PDF. Retorna '' se falhar ou for apenas imagem."""
+    tmp = RAW_DIR / "_tmp_extract.pdf"
+    try:
+        tmp.write_bytes(pdf_bytes)
+        with pdfplumber.open(tmp) as pdf:
+            pages = []
+            for page in pdf.pages[:60]:
+                t = page.extract_text()
+                if t:
+                    pages.append(t.strip())
+            return "\n".join(pages)
+    except Exception:
+        return ""
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+# ── 1. Candidatos ─────────────────────────────────────────────────────────────
+
+def load_candidates():
+    print("\n[1] Dados de candidatos...")
+    zp = RAW_DIR / "consulta_cand_2024.zip"
+    download(CAND_URL, zp, "candidatos 2024")
+
+    csv_dir = RAW_DIR / "cand_csv"
+    csv_dir.mkdir(exist_ok=True)
+    with zipfile.ZipFile(zp) as zf:
+        zf.extractall(csv_dir)
+
+    # Arquivo BRASIL ou concatenação de UFs
+    candidates_files = sorted(csv_dir.glob("consulta_cand_2024_BRASIL.csv"))
+    if not candidates_files:
+        candidates_files = sorted(csv_dir.glob("*.csv"))
+
+    dfs = []
+    for f in candidates_files:
+        try:
+            df = pd.read_csv(f, sep=";", encoding="latin1",
+                             low_memory=False, on_bad_lines="skip")
+            dfs.append(df)
+        except Exception as e:
+            print(f"  ✗ {f.name}: {e}")
+
+    if not dfs:
+        raise RuntimeError("Nenhum CSV de candidatos encontrado.")
+
+    df = pd.concat(dfs, ignore_index=True)
+    print(f"  Total de candidatos: {len(df):,}")
+
+    # Normalizar colunas
+    df.columns = [c.strip() for c in df.columns]
+
+    # Prefeitos (CD_CARGO == 11) – se coluna existir
+    if "CD_CARGO" in df.columns:
+        prefeitos = df[df["CD_CARGO"] == 11].copy()
+    elif "DS_CARGO" in df.columns:
+        prefeitos = df[df["DS_CARGO"].str.upper().str.contains("PREFEITO", na=False)].copy()
+    else:
+        prefeitos = df.copy()
+
+    print(f"  Candidatos a prefeito: {len(prefeitos):,}")
+    return df, prefeitos
+
+
+# ── 2. Download dos planos ────────────────────────────────────────────────────
+
+def download_plans() -> dict:
+    print("\n[2] Planos de governo por estado...")
+    result = {}
+    for uf in STATES:
+        dest = RAW_DIR / f"proposta_governo_2024_{uf}.zip"
+        ok = download(PLAN_URL.format(uf), dest, f"planos {uf}")
+        result[uf] = dest if ok else None
+    return result
+
+
+# ── 3. Extração de texto ──────────────────────────────────────────────────────
+
+def extract_texts(plan_zips: dict) -> tuple[dict, dict]:
+    """
+    Retorna:
+        texts  – {sq_candidato: {"uf": UF, "text": str}}
+        report – relatório de integridade
+    """
+    print("\n[3] Extraindo texto dos PDFs...")
+
+    report = {
+        "total_pdfs": 0, "with_text": 0,
+        "empty_scan": 0, "failed": 0,
+        "by_state": {},
+    }
+    texts: dict = {}
+
+    for uf, zp in plan_zips.items():
+        if zp is None or not zp.exists():
+            report["by_state"][uf] = {"total": 0, "with_text": 0, "empty": 0, "failed": 0}
+            continue
+
+        uf_txt = TXT_DIR / uf
+        uf_txt.mkdir(exist_ok=True)
+        st = {"total": 0, "with_text": 0, "empty": 0, "failed": 0}
+
+        try:
+            with zipfile.ZipFile(zp) as zf:
+                pdfs = [n for n in zf.namelist() if n.lower().endswith(".pdf")]
+                print(f"  {uf}: {len(pdfs)} PDFs")
+
+                for pdf_name in tqdm(pdfs, desc=f"  {uf}", leave=False):
+                    sq = Path(pdf_name).stem.strip()
+                    cache = uf_txt / f"{sq}.txt"
+                    st["total"] += 1
+                    report["total_pdfs"] += 1
+
+                    if cache.exists():
+                        text = cache.read_text("utf-8")
+                    else:
+                        try:
+                            raw = zf.read(pdf_name)
+                            text = pdf_to_text(raw)
+                        except Exception as e:
+                            print(f"    ✗ {sq}: {e}")
+                            text = ""
+                            st["failed"] += 1
+                            report["failed"] += 1
+                        cache.write_text(text, "utf-8")
+
+                    if text.strip():
+                        st["with_text"] += 1
+                        report["with_text"] += 1
+                    else:
+                        st["empty"] += 1
+                        report["empty_scan"] += 1
+
+                    texts[sq] = {"uf": uf, "text": text}
+
+        except Exception as e:
+            print(f"  ✗ erro ao abrir {zp.name}: {e}")
+
+        report["by_state"][uf] = st
+
+    pct = report["with_text"] / max(1, report["total_pdfs"]) * 100
+    print(f"\n  Resumo de extração:")
+    print(f"    PDFs totais    : {report['total_pdfs']:,}")
+    print(f"    Com texto      : {report['with_text']:,}  ({pct:.1f}%)")
+    print(f"    Sem texto(scan): {report['empty_scan']:,}")
+    print(f"    Com falha      : {report['failed']:,}")
+
+    return texts, report
+
+
+# ── 4. Cruzamento candidatos × textos ────────────────────────────────────────
+
+def build_candidates(prefeitos: pd.DataFrame, texts: dict) -> list[dict]:
+    print("\n[4] Cruzando candidatos com planos...")
+
+    col = lambda name: name if name in prefeitos.columns else None
+
+    cand_map: dict[str, dict] = {}
+    for _, row in prefeitos.iterrows():
+        sq = str(row.get("SQ_CANDIDATO", "")).strip()
+        cand_map[sq] = {
+            "id":           sq,
+            "nome":         str(row.get("NM_CANDIDATO", "")).strip(),
+            "nome_urna":    str(row.get("NM_URNA_CANDIDATO", "")).strip(),
+            "partido":      str(row.get("SG_PARTIDO", "")).strip(),
+            "uf":           str(row.get("SG_UF", "")).strip(),
+            "municipio":    str(row.get("NM_MUNICIPIO", "")).strip(),
+            "cd_municipio": str(row.get("CD_MUNICIPIO", "")).strip(),
+            "situacao":     str(row.get("DS_SITUACAO_CANDIDATURA", "")).strip(),
+            "has_plan":     False,
+            "text_len":     0,
+            "text":         "",
+        }
+
+    matched = 0
+    for sq, info in texts.items():
+        text = info["text"].strip()
+        if sq in cand_map:
+            if text:
+                cand_map[sq]["has_plan"] = True
+                cand_map[sq]["text_len"] = len(text)
+                cand_map[sq]["text"]     = text
+                matched += 1
+        else:
+            # PDF existe mas SQ não está no CSV de prefeitos (vereador / outra eleição)
+            if text:
+                cand_map[sq] = {
+                    "id": sq, "nome": f"Candidato {sq}", "nome_urna": "",
+                    "partido": "?", "uf": info["uf"], "municipio": "?",
+                    "cd_municipio": "", "situacao": "", "has_plan": True,
+                    "text_len": len(text), "text": text,
+                }
+
+    print(f"  Planos cruzados: {matched:,}")
+    return list(cand_map.values())
+
+
+# ── 5. Análise de temas ────────────────────────────────────────────────────────
+
+def analyze_themes(candidates: list[dict]) -> dict:
+    print("\n[5] Análise de temas...")
+    theme_data: dict = {}
+
+    for theme, keywords in THEMES.items():
+        kw_norm = [normalize(k) for k in keywords]
+        matches = []
+
+        for c in candidates:
+            text = c.get("text", "")
+            if not text:
+                continue
+            tn = normalize(text)
+
+            found_kw = []
+            snippet   = ""
+            for kw, kwn in zip(keywords, kw_norm):
+                idx = tn.find(kwn)
+                if idx != -1:
+                    found_kw.append(kw)
+                    if not snippet:
+                        s = max(0, idx - 80)
+                        e = min(len(text), idx + len(kw) + 150)
+                        snippet = "…" + text[s:e].strip() + "…"
+
+            if found_kw:
+                matches.append({
+                    "id":           c["id"],
+                    "nome":         c.get("nome_urna") or c["nome"],
+                    "partido":      c.get("partido", ""),
+                    "municipio":    c.get("municipio", ""),
+                    "uf":           c.get("uf", ""),
+                    "kws":          found_kw[:4],
+                    "snippet":      snippet[:300],
+                })
+
+        theme_data[theme] = {
+            "name":       theme,
+            "keywords":   keywords,
+            "count":      len(matches),
+            "candidates": matches,           # all – frontend paginates
+        }
+        print(f"  {theme:30s}: {len(matches):>6,} candidatos")
+
+    return theme_data
+
+
+# ── 6. Análise por partido ────────────────────────────────────────────────────
+
+def analyze_parties(candidates: list[dict]) -> dict:
+    print("\n[6] Análise por partido...")
+    parties: dict = defaultdict(lambda: {
+        "total": 0, "with_plan": 0,
+        "themes": defaultdict(int), "cands": [],
+    })
+
+    for c in candidates:
+        p = c.get("partido", "?") or "?"
+        parties[p]["total"] += 1
+        if c.get("has_plan"):
+            parties[p]["with_plan"] += 1
+            tn = normalize(c.get("text", ""))
+            for theme, keywords in THEMES.items():
+                for kw in keywords:
+                    if normalize(kw) in tn:
+                        parties[p]["themes"][theme] += 1
+                        break
+        parties[p]["cands"].append({
+            "id": c["id"],
+            "nome": c.get("nome_urna") or c["nome"],
+            "municipio": c.get("municipio", ""),
+            "uf": c.get("uf", ""),
+        })
+
+    result = {}
+    for p, d in parties.items():
+        result[p] = {
+            "party":        p,
+            "total":        d["total"],
+            "with_plan":    d["with_plan"],
+            "pct_plan":     round(d["with_plan"] / max(1, d["total"]) * 100, 1),
+            "themes":       dict(d["themes"]),
+            "cands_sample": d["cands"][:100],
+        }
+
+    print(f"  Partidos processados: {len(result)}")
+    return result
+
+
+# ── 7. Detecção de plágio ─────────────────────────────────────────────────────
+
+def get_ngrams(text: str, n: int) -> list[str]:
+    words = re.findall(r"[a-záéíóúàâêôãõüç]{3,}", text.lower())
+    return [" ".join(words[i:i+n]) for i in range(len(words) - n + 1)]
+
+
+def detect_plagiarism(candidates: list[dict],
+                      ngram_size: int = 9,
+                      min_copies: int = 3) -> dict:
+    """
+    Encontra trechos copiados entre planos de governo.
+    ngram_size : tamanho da janela de palavras (padrão 9)
+    min_copies : mínimo de candidatos distintos para ser plágio
+    """
+    print(f"\n[7] Detecção de plágio  (n-gram={ngram_size}, min_copies={min_copies})...")
+
+    with_text = [c for c in candidates if c.get("text") and len(c["text"]) > 300]
+    print(f"  Candidatos com texto: {len(with_text):,}")
+
+    # ngram → {set of candidate IDs}
+    ngram_index: dict[str, set] = defaultdict(set)
+
+    for c in with_text:
+        cid = c["id"]
+        for ng in set(get_ngrams(c["text"], ngram_size)):
+            ngram_index[ng].add(cid)
+
+    # Filtrar pelo mínimo de cópias
+    shared = {ng: ids for ng, ids in ngram_index.items() if len(ids) >= min_copies}
+    print(f"  N-grams compartilhados: {len(shared):,}")
+
+    # Ordenar por frequência (mais copiados primeiro)
+    top = sorted(shared.items(), key=lambda x: len(x[1]), reverse=True)[:300]
+
+    # Construir resultado
+    cand_lookup = {c["id"]: c for c in with_text}
+    copied_ids: set = set()
+    phrases = []
+
+    for phrase, ids in top:
+        ids_list = list(ids)
+        for cid in ids_list:
+            copied_ids.add(cid)
+
+        examples = []
+        for cid in ids_list[:5]:
+            c = cand_lookup.get(cid)
+            if not c:
+                continue
+            text = c["text"]
+            idx = text.lower().find(phrase.split()[0])
+            if idx != -1:
+                s = max(0, idx - 60)
+                e = min(len(text), idx + len(phrase) + 120)
+                ctx = text[s:e].strip()
+            else:
+                ctx = phrase
+            examples.append({
+                "id":        cid,
+                "nome":      c.get("nome_urna") or c["nome"],
+                "partido":   c.get("partido", ""),
+                "municipio": c.get("municipio", ""),
+                "uf":        c.get("uf", ""),
+                "context":   ctx[:400],
+            })
+
+        phrases.append({
+            "phrase":   phrase,
+            "count":    len(ids_list),
+            "cand_ids": ids_list[:200],
+            "examples": examples,
+        })
+
+    pct = len(copied_ids) / max(1, len(with_text)) * 100
+
+    result = {
+        "total_analyzed":           len(with_text),
+        "candidates_with_copies":   len(copied_ids),
+        "pct_with_copies":          round(pct, 1),
+        "unique_shared_phrases":    len(shared),
+        "top_phrases":              phrases,
+    }
+    print(f"  Candidatos com trechos copiados: {len(copied_ids):,}  ({pct:.1f}%)")
+    return result
+
+
+# ── 8. Exportação ─────────────────────────────────────────────────────────────
+
+def export_all(candidates, theme_data, party_data, plagiarism, report):
+    print("\n[8] Exportando JSONs...")
+
+    def dump(obj, path, indent=None):
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(obj, fh, ensure_ascii=False,
+                      separators=(",", ":") if indent is None else None,
+                      indent=indent)
+
+    # ── metadata.json ──────────────────────────────────────────────────────
+    meta = [
+        {k: c[k] for k in ("id","nome","nome_urna","partido","uf",
+                             "municipio","cd_municipio","has_plan","text_len")}
+        for c in candidates
+    ]
+    dump(meta, OUT_DIR / "metadata.json")
+    print(f"  metadata.json  : {len(meta):,} candidatos")
+
+    # ── report.json ────────────────────────────────────────────────────────
+    total     = len(candidates)
+    has_plan  = sum(1 for c in candidates if c.get("has_plan"))
+    rpt = {
+        "generated_at":    datetime.now().isoformat(),
+        "total_candidates": total,
+        "with_plan":        has_plan,
+        "without_plan":     total - has_plan,
+        "pct_with_plan":    round(has_plan / max(1, total) * 100, 1),
+        "extraction":       report,
+        "by_state":         {},
+    }
+    for uf in STATES:
+        uf_c = [c for c in candidates if c.get("uf") == uf]
+        wp   = sum(1 for c in uf_c if c.get("has_plan"))
+        rpt["by_state"][uf] = {
+            "total":     len(uf_c),
+            "with_plan": wp,
+            "pct":       round(wp / max(1, len(uf_c)) * 100, 1),
+        }
+    dump(rpt, OUT_DIR / "report.json", indent=2)
+
+    # ── Por estado ─────────────────────────────────────────────────────────
+    for uf in STATES:
+        uf_c = [c for c in candidates if c.get("uf") == uf]
+        uf_out = []
+        for c in uf_c:
+            entry = {k: c.get(k, "") for k in
+                     ("id","nome","nome_urna","partido","uf",
+                      "municipio","cd_municipio","has_plan","text_len")}
+            entry["snippet"] = (c.get("text","")[:400]) if c.get("has_plan") else ""
+            uf_out.append(entry)
+        dump(uf_out, OUT_DIR / "states" / f"{uf}.json")
+
+    # ── Candidatos individuais (full text) ─────────────────────────────────
+    ind_count = 0
+    for c in candidates:
+        if c.get("has_plan") and c.get("text"):
+            dump({
+                "id":        c["id"],
+                "nome":      c["nome"],
+                "nome_urna": c.get("nome_urna",""),
+                "partido":   c.get("partido",""),
+                "uf":        c.get("uf",""),
+                "municipio": c.get("municipio",""),
+                "text":      c["text"],
+            }, OUT_DIR / "candidates" / f"{c['id']}.json")
+            ind_count += 1
+    print(f"  Candidatos individuais: {ind_count:,}")
+
+    # ── Temas ──────────────────────────────────────────────────────────────
+    themes_index = []
+    for name, data in theme_data.items():
+        slug = re.sub(r"[^a-z0-9]+", "_", normalize(name)).strip("_")
+        dump(data, OUT_DIR / "themes" / f"{slug}.json")
+        themes_index.append({
+            "name":     name,
+            "slug":     slug,
+            "keywords": data["keywords"],
+            "count":    data["count"],
+        })
+    dump(themes_index, OUT_DIR / "themes.json", indent=2)
+    print(f"  Temas: {len(themes_index)}")
+
+    # ── Partidos ───────────────────────────────────────────────────────────
+    dump(party_data, OUT_DIR / "parties.json", indent=2)
+    print(f"  Partidos: {len(party_data)}")
+
+    # ── Plágio ─────────────────────────────────────────────────────────────
+    dump(plagiarism, OUT_DIR / "plagiarism.json", indent=2)
+    print("  plagiarism.json  ✓")
+
+    print("\n✓ Todos os arquivos exportados em:", OUT_DIR)
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("=" * 65)
+    print("Pipeline: Planos de Governo – Eleições Municipais 2024")
+    print("=" * 65)
+
+    df, prefeitos  = load_candidates()
+    plan_zips      = download_plans()
+    texts, extr_rp = extract_texts(plan_zips)
+    candidates     = build_candidates(prefeitos, texts)
+    theme_data     = analyze_themes(candidates)
+    party_data     = analyze_parties(candidates)
+    plagiarism     = detect_plagiarism(candidates)
+    export_all(candidates, theme_data, party_data, plagiarism, extr_rp)
+
+    print("\n✓ Pipeline concluído com sucesso!")


### PR DESCRIPTION
- Python pipeline (build_planos_governo_data.py) downloads all 27 state ZIPs from TSE, extracts PDF text via pdfplumber, generates integrity report, cross-references with candidate CSV, runs TF-IDF theme analysis across 30+ topics, party-level breakdowns, and n-gram plagiarism detection; exports optimized JSONs for the static dashboard
- planos-governo-dashboard/ with 5 tabs: Panorama (coverage KPIs + charts), Buscador (keyword search + pre-selected themes with UF/party/ city filters), Por partido (side-by-side party × theme comparison), Candidato vs candidato (full-text or theme-filtered side-by-side view), Análise de plágio (ranked copied phrases, candidate table, filters)
- Add link to dashboard in index.html Civil Tech section